### PR TITLE
Adds Simple RESTFul API and GraphQL in one project

### DIFF
--- a/restful-graphql-simple/app.js
+++ b/restful-graphql-simple/app.js
@@ -1,0 +1,29 @@
+const { ApolloServer, gql } = require("apollo-server-express");
+const express = require("express");
+const app = express();
+const port = 3000;
+
+const server = new ApolloServer({
+  typeDefs: gql`
+    type Query {
+      hello: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: () => "Say hi from GraphQL",
+    },
+  },
+});
+
+server.start().then(() => {
+  server.applyMiddleware({ app });
+});
+
+app.get("/api", (req, res, next) => {
+  res.send("Say hi from API");
+});
+
+app.listen(port, () => {
+  console.log(`listening on port ${port}`);
+});

--- a/restful-graphql-simple/package.json
+++ b/restful-graphql-simple/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "start:dev": "nodemon app.js"
+  },
+  "dependencies": {
+    "apollo-server-express": "^3.10.3",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.20"
+  }
+}


### PR DESCRIPTION
Referent from [How to Add a GraphQL Server to a RESTful Express.js API in 2 Minutes](https://www.freecodecamp.org/news/add-a-graphql-server-to-a-restful-express-js-api-in-2-minutes)